### PR TITLE
Remove empty CMD on `tc_new_container_request()`

### DIFF
--- a/testcontainers-c/testcontainers-c.go
+++ b/testcontainers-c/testcontainers-c.go
@@ -25,7 +25,6 @@ var customizers map[int][]*testcontainers.CustomizeRequestOption
 func tc_new_container_request(image *C.cchar_t) (id int) {
 	req := testcontainers.ContainerRequest{
 		Image: C.GoString(image),
-		Cmd:   []string{""},
 	}
 
 	containerRequests = append(containerRequests, &req)


### PR DESCRIPTION
Small fix for starting up a rabbitmq container using the generic containers implementation.

## What does this PR do?

Passing an empty string in the Cmd member of the ContainerRequest variable was causing a rabbitmq container to not launch properly. This change removes the empty string being passed to fix the issue.

## Why is it important?

Passing a Cmd to ContainerRequest is not needed for the current implementation, and removing this does not affect the WireMock demo either. So, the fix works all around.

## Related issues

Closes #24 

## How to test this PR

Compile and run the code from the issue (#24) and prove that the RabbitMQ container launches and does not stop immediately with the described error.