### PR TITLE
Add Support and Security pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img width="512px" src="docs/images/logo/logo_testcontainers_c_wide.png" alt="Testcontainers for C/C++ Logo"/>
 </p>
 
-[![Slack: testcontainers-c on slacktestcontainers.org](https://img.shields.io/badge/Slack-%23testcontainers%E2%80%94c-brightgreen?style=flat&logo=slack)](http://slack.testcontainers.org/)
+[![Slack: testcontainers-c on slack.testcontainers.org](https://img.shields.io/badge/Slack-%23testcontainers%E2%80%94c-brightgreen?style=flat&logo=slack)](http://slack.testcontainers.org/)
 [![Stability: Experimental](https://masterminds.github.io/stability/experimental.svg)](https://masterminds.github.io/stability/experimental.html)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/oleg-nenashev/testcontainers-c)](https://github.com/oleg-nenashev/testcontainers-c/releases)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,13 @@
+# Security
+
+## Reporting Security Issues
+
+You can submit any security issue or suspected vulnerability
+on [GitHub Security](https://github.com/testcontainers/testcontainers-c/security/advisories).
+Please do **NOT** use public GitHub Issues for reporting vulnerabilities.
+
+## Bug Bounty
+
+The Testcontainers for C/C++ project is not a part of the official Testcontainers bug bounty program and,
+as of now, of any other program.
+We will be happy to credit you in the public Security Advisory and on social media.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,35 @@
+# Support for Testcontainers for C/C++
+
+[![Slack: testcontainers-c on slack.testcontainers.org](https://img.shields.io/badge/Slack-%23testcontainers%E2%80%94c-brightgreen?style=flat&logo=slack)](http://slack.testcontainers.org/)
+
+Any bug reports, feature requests and comments are welcome!
+The project keeps evolving,
+and any feedback from end users and developers will be appreciated.
+
+## Community Support Channels
+
+Join the `#testcontainers-c` channel on the [Testcontainers Slack](http://slack.testcontainers.org/).
+At the moment, this is single channel for all project matters.
+
+## Raising Issues and Feature Requests
+
+Use [GitHub Issues](https://github.com/testcontainers/testcontainers-c/issues).
+Note that it may take some time to get a response, thanks for your patience.
+Contributions are always welcome, see the [Contributor Guide](../CONTRIBUTING.md).
+
+## Reporting Security Issues
+
+You can submit any security issue or suspected vulnerability
+on [GitHub Security](https://github.com/testcontainers/testcontainers-c/security/advisories).
+Please do NOT use public GitHub Issues for reporting vulnerabilities.
+
+Read More - [Security Policy](./SECURITY.md),
+
+## Commercial Support and Customization
+
+The creator of this project, Oleg Nenashev,
+is [available for consulting projects](https://oleg-nenashev.github.io/oleg-nenashev/consulting/) in the areas of developer tools,
+including Testcontainers for C/C++.
+Development of this project will continue regardless of commercial contracts,
+but of course your support can help the project to move forward.
+[GitHub Sponsorships](https://github.com/sponsors/oleg-nenashev) will be appreciated too.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,11 @@ nav:
     - Overview: modules/README.md
     - Embedded Modules:
       - WireMock: modules/wiremock/README.md
-  - Roadmap: ROADMAP.md
   - Contributing: CONTRIBUTING.md
+  - Resources:
+    - Roadmap: ROADMAP.md
+    - Support: docs/SUPPORT.md
+    - Security: docs/SECURITY.md
 
 plugins:
   - search
@@ -108,3 +111,4 @@ theme:
   logo: docs/images/logo/logo_testcontainers_c_square.png
   icon:
     repo: fontawesome/brands/github
+ 


### PR DESCRIPTION
Just a few helper GitHub Metadata pages, also included them in the documentation
